### PR TITLE
Endre hjelp.md fra `meta` til `page`

### DIFF
--- a/content/hjelp.md
+++ b/content/hjelp.md
@@ -1,5 +1,5 @@
 ---
-layout: meta
+layout: page
 title: Hjelp
 permalink: /hjelp/
 ---


### PR DESCRIPTION
Merket meg at [Travis CI klagde på at `meta` layout ikke finnes for `hjelp.md`](https://travis-ci.org/blankoslo/about-blank/builds/254959707#L322). Skal `meta` finnes, eller burde denne layouten være `page` ..?