### PR TITLE
Fix Sass build warning

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -63,7 +63,7 @@ header{
     margin:  0 0 1em -2rem;
     border-left: .5rem solid #D7D5D1;
     font-style: italic;
-    background-color: rgba(0,0,0,.05rem);
+    background-color: rgba(0,0,0,0.05);
     p{
       font-size: 1.25rem;
       line-height: 1.5rem;


### PR DESCRIPTION
Fikser [bygge-advarsel](https://travis-ci.org/blankoslo/about-blank/builds/255134248#L318)

>DEPRECATION WARNING: Passing a number with units as the alpha value to rgba() is deprecated and will be an error in future versions of Sass. Use 0.05 instead.